### PR TITLE
Oopsie! We broke some things!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu
 
 RUN apt-get update && apt-get install -y iproute2 tcpdump iputils-ping
+COPY ./init/sleep.sh /sleep.sh
 
-CMD ["bin/sleep 999999"]
+CMD ["/sleep.sh"]

--- a/init/sleep.sh
+++ b/init/sleep.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+while /bin/sleep 999999; do echo ""; done

--- a/notes/001-getting-started.md
+++ b/notes/001-getting-started.md
@@ -273,7 +273,6 @@ ip: RTNETLINK answers: Operation not permitted
 - Is this an issue with the busybox image?
 - Is this an issue with docker in general, and if so what other virtualization platforms might we look at instead?
 
-
 ## TODOs
 
 * WE LEFT OFF HERE!


### PR DESCRIPTION
This reverts portion of the commit f78bf7b67dcdbaf39f00aae4bd353aac20af26e1 that deals with removing init/sleep.sh but preserves the changes to the notes.