### PR TITLE
embed all image links into markdown link

### DIFF
--- a/appendix/how-to-read-a-network-map.md
+++ b/appendix/how-to-read-a-network-map.md
@@ -6,7 +6,8 @@ Everything that we build in this project depends on us understanding the shape o
 
 Let's start with a very simple network map:
 
-![basic-network-map](../img/network-maps/basic-network-map.svg)
+[![basic-network-map](../img/network-maps/basic-network-map.svg
+ "Basic Network Map")](../img/network-maps/basic-network-map.svg)
 
 So, what's going on here? First, what's probably most obvious about this map is that we have 2 machines on our network: a `Client` and a `Server`. Now, look at how each machine has a thin line coming out of it that connects it to a thicker line. That thick line symbolizes the network, and the thin lines from each machine symbolize their connections to that network.
 
@@ -18,7 +19,8 @@ So we've identified that the network is `10.1.1.0/24`, but we also need to know 
 
 So, we now know how to read a network map for a single network. But we're looking to build a full internet! That means multiple networks! Let's look at a slightly more complicated network map:
 
-![smol-internet-network-map](../img/network-maps/smol-internet-network-map.svg)
+[![smol-internet-network-map](../img/network-maps/smol-internet-network-map.svg
+ "A Smol Internet Network Map")](../img/network-maps/smol-internet-network-map.svg)
 
 OK, some of this should already look familiar. See if you can identify each of the following:
 
@@ -38,7 +40,8 @@ When we look at this network map, we can see that the `Router` has a connection 
 
 Alright, let's make this more interesting. Take a look at this slightly chonkier internet map:
 
-![chonky-internet-network-map](../img/network-maps/internet-chonk-network-map.svg)
+[![chonky-internet-network-map](../img/network-maps/internet-chonk-network-map.svg
+ "A Chonky Internet Network Map")](../img/network-maps/internet-chonk-network-map.svg)
 
 See if you can complete the following exercises:
 

--- a/appendix/recursive-dns.md
+++ b/appendix/recursive-dns.md
@@ -22,7 +22,8 @@ But why go through all this process? Why don't we just have those root servers a
 
 Before we can look at the process, we need to learn a little bit about the specific machines involved in DNS. We'll use a new network map with a few new machines defined on it:
 
-![large internet with DNS infrastructure](../img/network-maps/name-resolution/recursive-dns.svg)
+[![large internet with DNS infrastructure](../img/network-maps/name-resolution/recursive-dns.svg
+ "large internet with DNS infrastructure")](../img/network-maps/name-resolution/recursive-dns.svg)
 
 Let's briefly break down what we're seeing in this network map. If you haven't already, it would behoove you to read over [How to Read a Network Map](../../appendix/how-to-read-a-network-map.md) before continuing this section.
 
@@ -43,17 +44,20 @@ _**NOTE** For the purposes of this explanation, we're going to ignore that cachi
 
 First. Let’s just define the actual goal of what we’re trying to accomplish. Using the network map above, we're going to pretend we're sitting on a client machine.
 
-<img src="../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg" alt="large internet with DNS infrastructure with a pointer to the client machine" width="750"/>
+[![large internet with DNS infrastructure with a pointer to the client machine](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg
+ "large internet with DNS infrastructure with a pointer to the client machine")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg)
 
 Now, the user on this machine really wants to go visit `www.awesomecat.com`. Before the user can revel in GIFs and shorts of cats being awesome in the world, they need to resolve `www.awesomecat.com` to an IP address. The first thing this machine is going to do is send a request to their ISP's (Comcast in this case) recursive resolver.
 
-<img src="../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg" alt="large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted" width="750"/>
+[![large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg
+ "large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg)
 
 The recursive resolver's job is to keep asking questions about what the DNS records are for a name until it gets a final answer. It will continue to initiate new requests until it either receives a response with the DNS records it was looking for or it receives an error. Only then will it respond back to the client.
 
 So, what's the first thing it needs to do? It doesn't know what server on the internet might know about `www.awesomecat.com`. Fortunately, every resolver comes installed with a file called [root.hints](https://www.internic.net/domain/named.root). This file provides the resolver the IP addresses of ALL of the root servers around the world. Since, for this explanation, we're ignoring the cache, the only thing the resolver knows about on the internet are those root servers. It will start by firing off a request to the Root DNS servers, asking them what the IP address is for `www.awesomecat.com`.
 
-<img src="../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg" alt="large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted" width="750"/>
+[![large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg)
 
 The role of the Root DNS server on The Internet is simple. All they do is tell the resolver which Top Level Domain (TLD) servers to go to. Root DNS servers don't know all the DNS records for every domain on the internet. That would be way too many requests and waaaaaaaay too many domain names! What they do know is where the next step to find those answers lives.
 
@@ -61,7 +65,9 @@ Let's look at the domain we're attempting to lookup again: `www.awesomecat.com`.
 
 Our resolver receives the response back from the Root server, and it recognizes that this is not the final answer it's looking for. But! It also sees that it now has IP addresses of another server that has more information about the domain it's attempting to look up! So, our stalwart resolver fires off requests to the `COM` TLD servers.
 
-<img src="../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg" alt="large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted" width="750"/>
+[![large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg)
+
 
 Much like the Root DNS server, our TLD servers see way too much traffic to be able to provide answers to every DNS query that hits them. Instead, they too delegate.
 
@@ -71,7 +77,8 @@ So in the story of our little resolver trying to find the IP address for `www.aw
 
 Our resolver receives that response, and undeterred, it initiates another new request, this time to the Authoritative server it just learned about.
 
-<img src="../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg" alt="large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted" width="750"/>
+[![large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg)
 
 The request lands on the Authoritative DNS server for this domain, and that server actually knows about the domain! It's able to send back an IP address for a server that knows how to handle queries for `www.awesomecat.com`!!!
 

--- a/chapters/1.1-routing-getting-started/README.md
+++ b/chapters/1.1-routing-getting-started/README.md
@@ -6,7 +6,8 @@ We want to build a simple network where two machines can ping each other. To kee
 
 Here's what we expect our network to look like by the end of this chapter:
 
-![basic-network-map](../../img/network-maps/basic-network-map.svg)
+[![basic-network-map](../../img/network-maps/basic-network-map.svg
+ "Basic Network Map")](../../img/network-maps/basic-network-map.svg)
 
 In this diagram, there are 2 machines, `client` and `server`, who are a single network, `10.1.1.0/24`. That network can be understood as: all IP addresses in the range from `10.1.1.0` through `10.1.1.255`. Any machine on that network will have an IP address that is within that range, so `client` has the IP address `10.1.1.3` and `server` has the IP address `10.1.1.2`.
 

--- a/chapters/2.1-name-resolution-1-getting-started/README.md
+++ b/chapters/2.1-name-resolution-1-getting-started/README.md
@@ -6,7 +6,8 @@ What is name resolution? What problem(s) does it solve? In previous chapters, we
 
 Let's take a look at the internet we'll be working with for this chapter. You'll notice we've made some changes from the network diagrams we've used in other chapters. In _this_ internet, we have a bunch of [hosts](../glossary.md#host) that would like to communicate with each other:
 
-![our-inter-network](../../img/network-maps/name-resolution/nr-getting-started.svg)
+[![our-inter-network](../../img/network-maps/name-resolution/nr-getting-started.svg
+ "Our Inter-network")](../../img/network-maps/name-resolution/nr-getting-started.svg)
 
 Let's say we set this internet up for sharing fun pictures. Perhaps your passion is dancing photos, and host A (1.0.0.101) contains a massive library of `.jpg` files of this genre. Perhaps your friend Squee's passion is adorable kitty pictures, and their host B (5.0.0.102) has photos of that kind. When all of our friends set up their image-sharing hosts, we're going to end up with a bunch of machines that contain specific files we want access to.
 
@@ -183,6 +184,7 @@ root@host-a:/# links http://host-a
 
 As soon as you run this command, you'll see the full-screen text-based web-browsing majesty that is links:
 
-![links-welcome](../../img/links-welcome.jpg)
+[![links-welcome-screen](../../img/links-welcome.jpg
+ "links welcome screen")](../../img/links-welcome.jpg)
 
 Press `<enter>` on your keyboard to dismiss the welcome message. This is a text-based app to browse web-pages. It uses arrow-keys and tabs and enter and backspace in relatively intuitive way. Feel free to browse the documentation for it if you get stuck. Enjoy the amazing images! Also, notice that you can follow hyperlinks to all the other servers in this internet and explore the images on those systems as well!

--- a/chapters/2.2-name-resolution-2-host-synchronization/README.md
+++ b/chapters/2.2-name-resolution-2-host-synchronization/README.md
@@ -12,7 +12,8 @@ Let's start with the simplest thing we can do: we're gonna head down the route o
 
 First, let's check out what our little internet looks like for this chapter:
 
-![our-inter-network](../../img/network-maps/name-resolution/nr-multicast.svg)
+[![our-inter-network](../../img/network-maps/name-resolution/nr-multicast.svg
+ "Our Inter-network")](../../img/network-maps/name-resolution/nr-multicast.svg)
 
 The significant things to note about this internet are that we have 2 machines on one network, `host-c` and `host-f` are on `6.0.0.0/8`, and we added a new host, `host-h`, to the `4.0.0.0/8` network. `host-h` is only one hop away from `host-c` and `host-f`. This means that requests from `host-h` <=> `host-c` only need to be routed through one router. This simplifies what we're looking at when we are checking what's happening on our internet. We wanted to have a request path that involved one and only one router; adding `host-h` handled that for us.
 
@@ -437,7 +438,8 @@ Previously, we saw `router-3` proxying the request for name resolution for `host
 
 The name resolution request flow looks something like this:
 
-![flowchart of proxy broadcast through our internet](../../img/network-maps/name-resolution/proxy-broadcast.svg)
+[![flowchart of proxy broadcast through our internet](../../img/network-maps/name-resolution/proxy-broadcast.svg
+ "flowchart of proxy broadcast through our internet")](../../img/network-maps/name-resolution/proxy-broadcast.svg)
 
 Each arrow in this diagram indicates a new proxied request for name resolution for `host-h.local`. The color of the arrows indicates how far down the proxy chain that request is.
 
@@ -451,7 +453,8 @@ The result of these behaviors is that messages don't go around the internet fore
 
 Next, let's look at how the response makes its way to every machine as well.
 
-![flowchart of a proxy response through our internet](../../img/network-maps/name-resolution/proxy-response.svg)
+[![flowchart of a proxy response through our internet](../../img/network-maps/name-resolution/proxy-response.svg
+ "flowchart of a proxy response through our internet")](../../img/network-maps/name-resolution/proxy-response.svg)
 
 Here, we see that `host-h` generates the response message that gets broadcast to every router on the `4.0.0.0/8` network. Each router then proxies that message to each machine on each other network it has an interface on. As each router, in turn, does the same thing, this allows the response to flood back to every machine on the internet.
 

--- a/chapters/2.3-name-resolution-3-simple-dns/README.md
+++ b/chapters/2.3-name-resolution-3-simple-dns/README.md
@@ -13,7 +13,8 @@ For this chapter, we want to build a single server that is responsible for knowi
 
 Let's look at the internet we'll be working with for this chapter:
 
-![our-inter-network](../../img/network-maps/name-resolution/basic-dns-internet.svg)
+[![our-inter-network](../../img/network-maps/name-resolution/basic-dns-internet.svg
+ "Our Inter-network")](../../img/network-maps/name-resolution/basic-dns-internet.svg)
 
 Notice that our internet now has a server called `DNS` at `2.0.0.107`. This server provides Authoritative DNS services for our internet. If you check the directory for this chapter, you'll see that there's a new Dockerfile entry: `Dockerfile_dns`. This Dockerfile builds its image from a base image that includes DNS server software called `knot`. To achieve our goal for this chapter, we will need to:
 

--- a/chapters/2.4-name-resolution-recursive-dns/README.md
+++ b/chapters/2.4-name-resolution-recursive-dns/README.md
@@ -43,7 +43,8 @@ But why go through all this process? Why don't we just have those root servers a
 
 Before we can look at the process, we need to learn a little bit about the specific machines involved in DNS. We'll use a new network map with a few new machines defined on it:
 
-![large internet with DNS infrastructure](../../img/network-maps/name-resolution/recursive-dns.svg)
+[![large internet with DNS infrastructure](../../img/network-maps/name-resolution/recursive-dns.svg
+ "large internet with DNS infrastructure")](../../img/network-maps/name-resolution/recursive-dns.svg)
 
 Let's briefly break down what we're seeing in this network map. If you haven't already, it would behoove you to read over [How to Read a Network Map](../../appendix/how-to-read-a-network-map.md) before continuing this section.
 
@@ -64,17 +65,20 @@ _**NOTE** For the purposes of this explanation, we're going to ignore that cachi
 
 First. Let’s just define the actual goal of what we’re trying to accomplish. Using the network map above, we're going to pretend we're sitting on a client machine.
 
-<img src="../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg" alt="large internet with DNS infrastructure with a pointer to the client machine" width="750"/>
+[![large internet with DNS infrastructure with a pointer to the client machine](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg
+ "large internet with DNS infrastructure with a pointer to the client machine")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg)
 
 Now, the user on this machine really wants to go visit `www.awesomecat.com`. Before the user can revel in GIFs and shorts of cats being awesome in the world, they need to resolve `www.awesomecat.com` to an IP address. The first thing this machine is going to do is send a request to their ISP's (Comcast in this case) recursive resolver.
 
-<img src="../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg" alt="large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted" width="750"/>
+[![large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg
+ "large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg)
 
 The recursive resolver's job is to keep asking questions about what the DNS records are for a name until it gets a final answer. It will continue to initiate new requests until it either receives a response with the DNS records it was looking for or it receives an error. Only then will it respond back to the client.
 
 So, what's the first thing it needs to do? It doesn't know what server on the internet might know about `www.awesomecat.com`. Fortunately, every resolver comes installed with a file called [root.hints](https://www.internic.net/domain/named.root). This file provides the resolver the IP addresses of ALL of the root servers around the world. Since, for this explanation, we're ignoring the cache, the only thing the resolver knows about on the internet are those root servers. It will start by firing off a request to the Root DNS servers, asking them what the IP address is for `www.awesomecat.com`.
 
-<img src="../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg" alt="large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted" width="750"/>
+[![large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg)
 
 The role of the Root DNS server on The Internet is simple. All they do is tell the resolver which Top Level Domain (TLD) servers to go to. Root DNS servers don't know all the DNS records for every domain on the internet. That would be way too many requests and waaaaaaaay too many domain names! What they do know is where the next step to find those answers lives.
 
@@ -82,7 +86,8 @@ Let's look at the domain we're attempting to lookup again: `www.awesomecat.com`.
 
 Our resolver receives the response back from the Root server, and it recognizes that this is not the final answer it's looking for. But! It also sees that it now has IP addresses of another server that has more information about the domain it's attempting to look up! So, our stalwart resolver fires off requests to the `COM` TLD servers.
 
-<img src="../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg" alt="large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted" width="750"/>
+[![large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg)
 
 Much like the Root DNS server, our TLD servers see way too much traffic to be able to provide answers to every DNS query that hits them. Instead, they too delegate.
 
@@ -92,7 +97,8 @@ So in the story of our little resolver trying to find the IP address for `www.aw
 
 Our resolver receives that response, and undeterred, it initiates another new request, this time to the Authoritative server it just learned about.
 
-<img src="../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg" alt="large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted" width="750"/>
+[![large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg)
 
 The request lands on the Authoritative DNS server for this domain, and that server actually knows about the domain! It's able to send back an IP address for a server that knows how to handle queries for `www.awesomecat.com`!!!
 
@@ -388,7 +394,8 @@ Next, we're going to to play around in this system!
 
 This leads us to our map! If you need help understanding this map, check out our [appendix on how to read network maps](../../../appendix/how-to-read-a-network-map.md).
 
-![Network map of a large internetwork](../../img/network-maps/name-resolution/recursive-dns.svg)
+[![Network map of a large internetwork](../../img/network-maps/name-resolution/recursive-dns.svg
+ "Network map of a large internetwork")](../../img/network-maps/name-resolution/recursive-dns.svg)
 
 You might recognize some of these new machines from our previous description on how recursive DNS works. See if you can find the machines that are part of the complete DNS infrastructure, including:
 
@@ -1147,7 +1154,8 @@ That's it! What we just looked at should have felt pretty familiar in comparison
 
 Now that we've built out some of the infrastructure together, let's take a stab at adding a few more elements to this toy internet. First, we'd like to bring your attention to a new network, "RIPE":
 
-![Network map including the RIPE network](../../img/network-maps/name-resolution/recursive-dns-final-exercises.svg)
+[![Network map including the RIPE network](../../img/network-maps/name-resolution/recursive-dns-final-exercises.svg
+ "Network map including the RIPE network")](../../img/network-maps/name-resolution/recursive-dns-final-exercises.svg)
 
 So now we're going to have you do a couple more exercises to make sure you have enough practice configuring DNS-related software. To that end, we have a **new** rootdns and a **new** resolver. Your task is to configure them so they function correctly in our toy internet! In each case, it would be helpful to go check (and potentially copy) the config files for similar machines on our internet.
 


### PR DESCRIPTION
In order to allow users viewing the documentation to easily click on a an image to get the full-size variant, embed all image links into a markdown link.

Include title (alternate text) for each of the images, which can (and will) be used as hover text in (most) presentational UIs.

Tested with GFM Markdown.