### PR TITLE
minor markdown fixes: indent list code blocks, tables

### DIFF
--- a/SET-UP-LAB-NODE.md
+++ b/SET-UP-LAB-NODE.md
@@ -1,4 +1,4 @@
-# You might want to set up a lab node to run BYOI. Here's how to do that.
+# Setting up a Lab Node
 
 ## Starting with digital ocean
 
@@ -10,123 +10,123 @@ set up with ssh access.
 
 2. Authenticate with doctl:
 
-  ```bash
-  doctl auth init
-  ```
+    ```bash
+    doctl auth init
+    ```
 
 3. If you don't have an ssh key, create one with the following command:
 
-  ```bash
-  ssh-keygen -t ed25519
-  ```
+    ```bash
+    ssh-keygen -t ed25519
+    ```
 
 4. Add the ssh key to your digital ocean account with the following command:
 
-  ```bash
-  doctl compute ssh-key add --ssh-key-file ~/.ssh/id_ed25519.pub
-  ```
+    ```bash
+    doctl compute ssh-key add --ssh-key-file ~/.ssh/id_ed25519.pub
+    ```
 
 5. List your ssh keys with the following command:
 
-  ```bash
-  doctl compute ssh-key list
-  ```
+    ```bash
+    doctl compute ssh-key list
+    ```
 
 6. Set your ssh key ID as an environment variable:
 
-  ```bash
-  export SSH_KEY_ID=<your-ssh-key-id>
-  ```
+    ```bash
+    export SSH_KEY_ID=<your-ssh-key-id>
+    ```
 
 ### Building the lab node
 
 1. Create a droplet with the following command:
 
-  ```bash
-  export HOST_NAME=build-your-own-internet-lab-3
-  doctl compute droplet create \
-      --ssh-keys $SSH_KEY_ID \
-      --image ubuntu-24-04-x64 \
-      --size s-2vcpu-4gb \
-      --region sfo3 \
-      --vpc-uuid cf4f0a3a-a4b6-4ced-8378-19c060c48bd6 \
-      $HOST_NAME
-  ```
+    ```bash
+    export HOST_NAME=build-your-own-internet-lab-3
+    doctl compute droplet create \
+        --ssh-keys $SSH_KEY_ID \
+        --image ubuntu-24-04-x64 \
+        --size s-2vcpu-4gb \
+        --region sfo3 \
+        --vpc-uuid cf4f0a3a-a4b6-4ced-8378-19c060c48bd6 \
+        $HOST_NAME
+    ```
 
 2. Find the IP address of the droplet with the following command:
 
-  ```bash
-  while sleep 1; do
-  doctl compute droplet list --format ID,Name,PublicIPv4,PrivateIPv4
-  done
-  ```
+    ```bash
+    while sleep 1; do
+    doctl compute droplet list --format ID,Name,PublicIPv4,PrivateIPv4
+    done
+    ```
 
-> 📝 NOTE: It may take a few minutes for the droplet to become active and for it to have an IP address.
+    > 📝 NOTE: It may take a few minutes for the droplet to become active and for it to have an IP address.
 
-Assign that IP address to the `IP_ADDRESS` environment variable:
+    Assign that IP address to the `IP_ADDRESS` environment variable:
 
-  ```bash
-  export IP_ADDRESS=<your-ip-address>
-  ```
+    ```bash
+    export IP_ADDRESS=<your-ip-address>
+    ```
 
 3. SSH into the droplet with the following command:
 
-  ```bash
-  $ ssh root@$IP_ADDRESS
-  The authenticity of host '137.184.179.253 (137.184.179.253)' can't be established.
-  ED25519 key fingerprint is SHA256:ecjoIp/DNuZIvKIWdoVOhKedryaBhgjRZooH1iYMKGU.
-  This key is not known by any other names.
-  Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
-  ```
+    ```bash
+    $ ssh root@$IP_ADDRESS
+    The authenticity of host '137.184.179.253 (137.184.179.253)' can't be established.
+    ED25519 key fingerprint is SHA256:ecjoIp/DNuZIvKIWdoVOhKedryaBhgjRZooH1iYMKGU.
+    This key is not known by any other names.
+    Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+    ```
 
 4. Clone down the BYOI repo and run the playbook to set up the test user:
 
-  ```bash
-  git clone https://github.com/build-your-own-internet/byoi.git
-  ```
+    ```bash
+    git clone https://github.com/build-your-own-internet/byoi.git
+    ```
 
 5. Switch to the appropriate branch
 
-  ```bash
-  cd byoi
-  git checkout tech-summit-2024-base
-  ```
+    ```bash
+    cd byoi
+    git checkout tech-summit-2024-base
+    ```
 
 6. Install Ansible:
 
-  ```bash
-  cd ansible-setup/
-  apt update;apt install -y software-properties-common;add-apt-repository --yes --update ppa:ansible/ansible;apt install -y ansible;
-  ```
+    ```bash
+    cd ansible-setup/
+    apt update;apt install -y software-properties-common;add-apt-repository --yes --update ppa:ansible/ansible;apt install -y ansible;
+    ```
 
 7. Set the test user password:
 
-Ansible requires that passwords be provided in an encrypted (hashed) format when setting user passwords. To set the password securely without storing it in the playbook, we can use an environment variable to pass the hashed password to the playbook.
+    Ansible requires that passwords be provided in an encrypted (hashed) format when setting user passwords. To set the password securely without storing it in the playbook, we can use an environment variable to pass the hashed password to the playbook.
 
-  ```bash
-  export TEST_USER_PASSWORD=$(openssl passwd -6 "your-super-secret-password")
-  ```
+    ```bash
+    export TEST_USER_PASSWORD=$(openssl passwd -6 "your-super-secret-password")
+    ```
 
 8. Run the playbook:
 
-  ```bash
-  ansible-playbook setup_test_user.yml
-  ```
+    ```bash
+    ansible-playbook setup_test_user.yml
+    ```
 
 9. Test that the test user can run BYOI commands:
 
-Log out of the droplet. Then log back in as the test user with the following command:
+    Log out of the droplet. Then log back in as the test user with the following command:
 
-  ```bash
-  ssh test@$IP_ADDRESS
-  ```
+    ```bash
+    ssh test@$IP_ADDRESS
+    ```
 
 10. Start the BYOI lab server:
 
-Now, as the test user, run the following command to start the BYOI lab server:
+    Now, as the test user, run the following command to start the BYOI lab server:
 
-  ```bash
-  byoi-rebuild
-  ```
+    ```bash
+    byoi-rebuild
+    ```
 
 You're done!

--- a/appendix/ip-and-mac-addresses.md
+++ b/appendix/ip-and-mac-addresses.md
@@ -1,6 +1,6 @@
 # IP and Ethernet Addresses
 
-Once upon a time, when computers were new and nobody knew what was possible with them, some people decided that it would be fun to be able to connect a few of them together and have them communicate with each other. There were many ideas about the most efficient way to accomplish this. Some companies developed proprietary solutions while other solutions were developed by governments or academic institutions. 
+Once upon a time, when computers were new and nobody knew what was possible with them, some people decided that it would be fun to be able to connect a few of them together and have them communicate with each other. There were many ideas about the most efficient way to accomplish this. Some companies developed proprietary solutions while other solutions were developed by governments or academic institutions.
 
 After decades of evolution, two technologies became dominant: Ethernet and IP. Ethernet dominated the “local-network” landscape because it was simple, fast, and ubiquitous. Unlike most of its competitors, it was not proprietary, so you could buy cheap off-the-shelf equipment. You could buy cables, cut them to length, and crimp on ends yourself. Ethernet had a lot of technical limitations, but because of the simplicity of its design, people developed solutions that allowed it to grow from 10 megabits-per-second (MBPS) to 100 gigabits-per-second while still being largely backwards-compatible. Your WiFi router has Ethernet ports on it. If you want to get a network interface for your computer, the only thing you’re likely to be able to find for it is Ethernet. If you go to any datacenter in the world, the vast majority of the network cabling will be Ethernet. If you buy a network-based video-camera or speaker, they all use Ethernet. It’s that slightly-wide “telephone jack” (are there people reading this that don’t know what a telephone jack is? 😂) that you see everywhere.
 
@@ -13,7 +13,6 @@ Because of this, there are two different **kinds** of addresses that we need to 
 The other address your computer has is an IP address, and they typically look like `192.23.33.12`. Unlike MAC addresses which are generally burned into the silicon, IP addresses are more malleable and can be reassigned as necessary.
 
 So, how does all this work together? Let’s take a look at what a typical home network might look like:
-
 
 ```markdown
 ┌────────┐   ┌─────────────┐   ┌───────────┐

--- a/appendix/prefixes-and-subnet-masks.md
+++ b/appendix/prefixes-and-subnet-masks.md
@@ -143,7 +143,7 @@ This might sound like gibberish to begin with. Don't worry! We'll spell it out i
     1. **If they match**: use that route 🙂
     2. **If they do not match**: go on to the next route 😞
 
-#### Example
+#### Example packet 10.2.1.4 - does it match 10.1.0.0/24?
 
 Let's go through an example of this. We're looking at one router on the Internet, and let's say it has the following routing table:
 
@@ -158,7 +158,7 @@ Let's say this router sees a packet coming in destined for `10.2.1.4`. The route
 
 To accomplish this, it's going to go through the routing table and apply the algorithm to each route until it finds a match. Let's say it starts with the first route in the table: `10.1.0.0/24`.
 
-##### Step 1
+##### Step 1 - attempting 10.1.0.0/24
 
 > Take the subnet-mask of the current route and perform a bitwise AND operation with the destination IP address of the packet we're routing.
 
@@ -191,7 +191,7 @@ So, we started a destination address of `10.2.1.4`. We’re checking to see if i
 
 > By the way, did you notice that the result of applying the "subnet mask" to an IP address is that it just "masks out" (kinda like masking tape) part of the address? That's why it's called a "mask"! It just acts like a filter: anywhere there's a `1` in the mask, we take the value of the address. Anywhere there's a `0` in the mask, we ignore the value of the address!
 
-##### Step 2
+##### Step 2 - attempting 10.1.0.0/24
 
 > Take the network address of the current route and compare that with the previous result
 > If they match: use that route
@@ -203,7 +203,7 @@ The network address, everything _before_ the "/24", of the current route is `10.
 
 Okay, the first route didn’t work out. But we’re not frightened. We have more routes to check, and we are pretending to be a tireless computer! So, okay, chin up soldier: the next route is `10.2.0.0/23`. Let's go through the same two-step process that we did for the first route.
 
-##### Step 1
+##### Step 1 - attempting 10.2.0.0/24
 
 We apply the subnet mask (`/23`) to the destination IP address (`10.2.1.4`):
 
@@ -216,7 +216,7 @@ result:              00001010.00000010.00000000.00000000
 
 ...and if we convert the octets of the result back to decimal, we get `10.2.0.0`.
 
-##### Step 2
+##### Step 2 - attempting 10.2.0.0/24
 
 Next, we take the network address of the **current route** (10.2.0.0) and compare that with the result of step 1 (10.2.0.0).
 


### PR DESCRIPTION
minor markdown fixes: indent list code blocks, tables

Switch to indented code blocks inside lists.  Some markdown markdown engines
will not present lists as expected unless fences (code blocks) are indented
exactly four spaces.  The GitHub markdown rendering engine is forgiving and
numbers the lists correctly.  Other, stricter markdown rendering engines will
restart the numbering of the list items.

Apply strict interpretation of whitespace handling (no whitespace at ends of
lines unless signifying continuations) and no more than the necessary number of
blank lines. Because Markdown is flexible (perhaps too much so), it must care
quite particularly about whitespace.  Not all markdown engines are so
forgiving.  In short, apply Postel's law, a.k.a. the Robustness Principle [0].

Replace HTML tables with Markdown. Use Github Flavored Markdown (GFM)
compatible [1] and Commonmark [2] style tables.  Depending on complexity, it is
usually acceptable to embed HTML in Markdown.  Nevertheless, this can make the
Markdown more difficult to manipulate (or understand).  Table format in
Markdown is fairly easy to read.

 [0] https://en.wikipedia.org/wiki/Robustness_principle
 [1] https://github.github.com/gfm/
 [2] https://spec.commonmark.org/0.31.2/
