### PR TITLE
fixes: markdown tables and spacing; link updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ When writing a new chapter, we have frequently encountered situations where we'r
 
 This project started because the authors all wanted to get practical, hands on experiences with the various technologies and protocols that make the internet work. That means we didn't always know where to start with a chapter. This is good. This means that we had really obvious growth opportunities and we got to tangibly experience our learning processes!!! When we approached large topics that we understood in theory, we didn't think about the chapter yet. Instead, we just played around until we got something working. Once we had a better understanding of how the system/technology/protocol worked, we could start thinking about what the chapter itself might look like. Usually, we needed to write several smaller chapters before we could implement the fully fledged system we dreamed of.
 
-The first thing we keep in mind when we're developing content for a topic is making sure the reader understands the problem first. Once the reader can get hands on experience with a problem, then we attempt to implement the simplest solution we can think of for the problem. The solutions we reach for are imperfect. They might not be implemented broadly. They may have only been implemented in a more nacent version of The Internet. However, the basic solution gives the reader a foundation to build on. 
+The first thing we keep in mind when we're developing content for a topic is making sure the reader understands the problem first. Once the reader can get hands on experience with a problem, then we attempt to implement the simplest solution we can think of for the problem. The solutions we reach for are imperfect. They might not be implemented broadly. They may have only been implemented in a more nacent version of The Internet. However, the basic solution gives the reader a foundation to build on.
 
-Once we have an initial solution, we can start poking holes in that solution. Does it scale? Is it secure? Is it maintainable? And finally... what does the actual modern internet do? We want to end with a solution that looks as close to the current internet as possible. 
+Once we have an initial solution, we can start poking holes in that solution. Does it scale? Is it secure? Is it maintainable? And finally... what does the actual modern internet do? We want to end with a solution that looks as close to the current internet as possible.
 
 So writing a chapter might look like this:
 
@@ -22,7 +22,7 @@ Ok, let's take it back even further. How do we create a secure connection just b
 
 So this comes down to "what's the most fundamental part of what we made that we can break apart and explain to the reader". If all else fails, look at how the real internet was actually developed over time. The internet didn't start with TLS. That was a solution that came as the internet grew more and more massive. So let's go back to the first problem we're trying to solve and let's see how we can solve that in the simplest way.
 
-We always want to start with the problem. For TLS, this means we write a chapter/section that demonstrates an EVIL server intercepting packets meant for a legitimate server. The reader then has the hands on experience of the problem. 
+We always want to start with the problem. For TLS, this means we write a chapter/section that demonstrates an EVIL server intercepting packets meant for a legitimate server. The reader then has the hands on experience of the problem.
 
 Now we can move into finding a solution. In most cases, the first solution we want to implement is going to focus on connecting just 2 machines. Don't worry about an internet. Worry about the _most basic_ implementation!
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We decided to take notes that create a reproducible experience. We document our 
 
 ### Software
 
-You will need to install [colima](https://smallsharpsoftwaretools.com/tutorials/use-colima-to-run-docker-containers-on-macos/) or [docker desktop](https://www.docker.com/products/docker-desktop/) to manage your docker instances. We go into more detail what these software are and how to get started with them in [our prequel chapter 000](./chapters/000-prequel-how-does-this-work/README.md).
+You will need to install [colima](https://smallsharpsoftwaretools.com/tutorials/use-colima-to-run-docker-containers-on-macos/) or [docker desktop](https://www.docker.com/products/docker-desktop/) to manage your docker instances. We go into more detail what these software are and how to get started with them in [our prequel chapter 000](./chapters/000-getting-started/README.md).
 
 ## DISCLAIMERS
 

--- a/appendix/prefixes-and-subnet-masks.md
+++ b/appendix/prefixes-and-subnet-masks.md
@@ -13,98 +13,22 @@ A “prefix” and a “subnet mask” are the 2 parts that comprise a network a
 
 The structure of the addresses we’re looking at is numbers split into 4 chunks separated by a dot (.). Each of these chunks is referred to as an “octet”. Why an octet? Because each number is a decimal (base10) representation of an 8-bit binary number. That’s why they only go up to 255 in any one of the octets. We can convert each 8 bit binary number to a decimal value. Check this out:
 
-<table>
-  <tr>
-   <td>Value in Binary
-   </td>
-   <td>Value in Decimal
-   </td>
-  </tr>
-  <tr>
-   <td>0000 0000
-   </td>
-   <td>0
-   </td>
-  </tr>
-  <tr>
-   <td>0000 0001
-   </td>
-   <td>1
-   </td>
-  </tr>
-  <tr>
-   <td>0000 0010
-   </td>
-   <td>2
-   </td>
-  </tr>
-  <tr>
-   <td>0000 0011
-   </td>
-   <td>3
-   </td>
-  </tr>
-  <tr>
-   <td>0000 0100
-   </td>
-   <td>4
-   </td>
-  </tr>
-  <tr>
-   <td>0000 0101
-   </td>
-   <td>5
-   </td>
-  </tr>
-  <tr>
-   <td>0000 0110
-   </td>
-   <td>6
-   </td>
-  </tr>
-  <tr>
-   <td>0000 0111
-   </td>
-   <td>7
-   </td>
-  </tr>
-  <tr>
-   <td>0000 1000
-   </td>
-   <td>8
-   </td>
-  </tr>
-  <tr>
-   <td>0001 0000
-   </td>
-   <td>16
-   </td>
-  </tr>
-  <tr>
-   <td>0010 0000
-   </td>
-   <td>32
-   </td>
-  </tr>
-  <tr>
-   <td>0100 0000
-   </td>
-   <td>64
-   </td>
-  </tr>
-  <tr>
-   <td>1000 0000
-   </td>
-   <td>128
-   </td>
-  </tr>
-  <tr>
-   <td>1111 1111
-   </td>
-   <td>255
-   </td>
-  </tr>
-</table>
+| Value in Binary | Value in Decimal |
+| --------------: | ---------------: |
+| 0000 0000       | 0                |
+| 0000 0001       | 1                |
+| 0000 0010       | 2                |
+| 0000 0011       | 3                |
+| 0000 0100       | 4                |
+| 0000 0101       | 5                |
+| 0000 0110       | 6                |
+| 0000 0111       | 7                |
+| 0000 1000       | 8                |
+| 0001 0000       | 16               |
+| 0010 0000       | 32               |
+| 0100 0000       | 64               |
+| 1000 0000       | 128              |
+| 1111 1111       | 255              |
 
 What we see happening here is that each value in our 8-bit number corresponds with a decimal value. Oddly, [this children’s program](https://www.youtube.com/watch?v=VpDDPWVn5-Q) is the best explanation of binary I’ve ever found.
 
@@ -114,11 +38,17 @@ It’s easy to look at an IP address and try to make it more complicated than it
 
 So, back to binary. If we translate each octet of Fastly’s IP address range into binary, we’ll see:
 
+```none
 151.101.0.0 => 10010111.01100101.00000000.00000000
+                  151      101      0        0
+```
 
+```none
 151.101.255.255 => 10010111.01100101.11111111.11111111
+                      151      101       0       0
+```
 
-Those octets are much harder on the human brain to comprehend and communicate. Instead, we perform a conversion on the binary values to translate each octet into decimal numbers that we are more accustomed to.
+Those binary octets are much harder on the human brain to comprehend and communicate. Instead, we perform a conversion on the binary values to translate each octet into decimal numbers (still called octets) that we are more accustomed to.
 
 ## Routing
 
@@ -232,48 +162,12 @@ What we just described in the previous section is how to determine if a destinat
 
 Let’s look at some prefixes and the range of IP addresses they provide.
 
-<table>
-  <tr>
-   <td>Subnet Mask
-   </td>
-   <td>Applied Prefix
-   </td>
-   <td>Sample IP Range
-   </td>
-  </tr>
-  <tr>
-   <td>/24
-   </td>
-   <td>151.101.0.0/24
-   </td>
-   <td>151.101.0.0 - 151.101.0.255
-   </td>
-  </tr>
-  <tr>
-   <td>/23
-   </td>
-   <td>151.101.0.0/23
-   </td>
-   <td>151.101.0.0 - 151.101.1.255
-   </td>
-  </tr>
-  <tr>
-   <td>/22
-   </td>
-   <td>151.101.0.0/22
-   </td>
-   <td>151.101.0.0 - 151.101.3.255
-   </td>
-  </tr>
-  <tr>
-   <td>/16
-   </td>
-   <td>151.101.0.0/16
-   </td>
-   <td>151.101.0.0 - 151.101.255.255
-   </td>
-  </tr>
-</table>
+| Subnet Mask    | Applied Prefix | Sample IP Range                |
+| :------------- | :------------- | :----------------------------- |
+| /24            | 151.101.0.0/24 | 151.101.0.0 - 151.101.0.255    |
+| /23            | 151.101.0.0/23 | 151.101.0.0 - 151.101.1.255    |
+| /22            | 151.101.0.0/22 | 151.101.0.0 - 151.101.3.255    |
+| /16            | 151.101.0.0/16 | 151.101.0.0 - 151.101.255.255  |
 
 Did you notice the pattern there? Eh? Eh?! The values at the upper end of the IP range increase at the same rate as our next binary value! So we double the number of possible IP addresses between /24 & /23. Then we double it again between /23 & /22. Etc. Etc. Etc.
 

--- a/appendix/recursive-dns.md
+++ b/appendix/recursive-dns.md
@@ -25,7 +25,7 @@ Before we can look at the process, we need to learn a little bit about the speci
 [![large internet with DNS infrastructure](../img/network-maps/name-resolution/recursive-dns.svg
  "large internet with DNS infrastructure")](../img/network-maps/name-resolution/recursive-dns.svg)
 
-Let's briefly break down what we're seeing in this network map. If you haven't already, it would behoove you to read over [How to Read a Network Map](../../appendix/how-to-read-a-network-map.md) before continuing this section.
+Let's briefly break down what we're seeing in this network map. If you haven't already, it would behoove you to read over [How to Read a Network Map](how-to-read-a-network-map.md) before continuing this section.
 
 One major thing we added to this map is that the internet is made up of networks of networks. But the networks aren't necessarily a single prefix. Within a network, the owner can break up it's IP addresses however they want. So this network map shows that the internet knows about Comcast, for example, as a network. But within Comcast, they've broken up their larger prefixes. This bit is largely irrelevant to this discussion, but we wanted to call that out to avoid confusion!
 
@@ -44,20 +44,20 @@ _**NOTE** For the purposes of this explanation, we're going to ignore that cachi
 
 First. Let’s just define the actual goal of what we’re trying to accomplish. Using the network map above, we're going to pretend we're sitting on a client machine.
 
-[![large internet with DNS infrastructure with a pointer to the client machine](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg
- "large internet with DNS infrastructure with a pointer to the client machine")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg)
+[![large internet with DNS infrastructure with a pointer to the client machine](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg
+ "large internet with DNS infrastructure with a pointer to the client machine")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg)
 
 Now, the user on this machine really wants to go visit `www.awesomecat.com`. Before the user can revel in GIFs and shorts of cats being awesome in the world, they need to resolve `www.awesomecat.com` to an IP address. The first thing this machine is going to do is send a request to their ISP's (Comcast in this case) recursive resolver.
 
-[![large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg
- "large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg)
+[![large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg
+ "large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg)
 
 The recursive resolver's job is to keep asking questions about what the DNS records are for a name until it gets a final answer. It will continue to initiate new requests until it either receives a response with the DNS records it was looking for or it receives an error. Only then will it respond back to the client.
 
 So, what's the first thing it needs to do? It doesn't know what server on the internet might know about `www.awesomecat.com`. Fortunately, every resolver comes installed with a file called [root.hints](https://www.internic.net/domain/named.root). This file provides the resolver the IP addresses of ALL of the root servers around the world. Since, for this explanation, we're ignoring the cache, the only thing the resolver knows about on the internet are those root servers. It will start by firing off a request to the Root DNS servers, asking them what the IP address is for `www.awesomecat.com`.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg)
+[![large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg)
 
 The role of the Root DNS server on The Internet is simple. All they do is tell the resolver which Top Level Domain (TLD) servers to go to. Root DNS servers don't know all the DNS records for every domain on the internet. That would be way too many requests and waaaaaaaay too many domain names! What they do know is where the next step to find those answers lives.
 
@@ -65,8 +65,8 @@ Let's look at the domain we're attempting to lookup again: `www.awesomecat.com`.
 
 Our resolver receives the response back from the Root server, and it recognizes that this is not the final answer it's looking for. But! It also sees that it now has IP addresses of another server that has more information about the domain it's attempting to look up! So, our stalwart resolver fires off requests to the `COM` TLD servers.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg)
+[![large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg)
 
 
 Much like the Root DNS server, our TLD servers see way too much traffic to be able to provide answers to every DNS query that hits them. Instead, they too delegate.
@@ -77,8 +77,8 @@ So in the story of our little resolver trying to find the IP address for `www.aw
 
 Our resolver receives that response, and undeterred, it initiates another new request, this time to the Authoritative server it just learned about.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg)
+[![large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg
+ "large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg)
 
 The request lands on the Authoritative DNS server for this domain, and that server actually knows about the domain! It's able to send back an IP address for a server that knows how to handle queries for `www.awesomecat.com`!!!
 
@@ -368,4 +368,4 @@ So let's review what just happened here.
 - The authoritative server keeps track of the DNS records for any domain it is responsible for.
 - Once the resolver has an answer, it will send the final response back to the client who initiated the query.
 
-If you'd like to play around in this system, checkout our chapter on [name resolution with recursive DNS](../future/name-resolution/recursive-dns/)!
+If you'd like to play around in this system, checkout our chapter on [name resolution with recursive DNS](../chapters/2.4-name-resolution-recursive-dns/README.md)!

--- a/chapters/1.2-routing-smol-internet/README.md
+++ b/chapters/1.2-routing-smol-internet/README.md
@@ -6,7 +6,8 @@ In the previous chapter, we build a small network of 2 machines that could ping 
 
 Here's what we expect our internet to look like by the end of this chapter:
 
-![smol-internet-network-map](../../img/network-maps/smol-internet-network-map.svg)
+[![smol-internet-network-map](../../img/network-maps/smol-internet-network-map.svg
+ "A Smol Internet Network Map")](../../img/network-maps/smol-internet-network-map.svg)
 
 You'll notice in this network diagram that we've built on the smol network from Chapter 1.1. Here, we've added a new network, `10.1.2.0/24`, and we've added a new machine, `router`. A [router](../glossary.md#router-aka-gateway) is a machine that has an [interface](../glossary.md#interface) on multiple networks and can forward packets across those networks. In this case, our router has an interface on both `10.1.1.0/24` and `10.1.2.0/24`.
 

--- a/chapters/2.2-name-resolution-2-host-synchronization/README.md
+++ b/chapters/2.2-name-resolution-2-host-synchronization/README.md
@@ -21,7 +21,7 @@ The significant things to note about this internet are that we have 2 machines o
 
 Avahi is a program which uses [multicast](../glossary.md#multicast) to perform name resolution on local networks with minimal configuration. If you check the [Dockerfile](./Dockerfile) for this chapter, you'll see that we added a new software, `avahi-utils`.
 
-As you might recall, in [chapter 1](../name-resolution-1-getting-started/README.md#how-does-your-computer-know-where-to-go-to-resolve-a-name), we took a look at the contents of `/etc/nsswitch.conf`. We saw that the `hosts` line provided instructions for how to resolve a name. The order runs sequentially through each entry in that line; it starts with looking at the `files` on the system (i.e. `/etc/hosts`), and, if it doesn't find the name there, then it should use `dns` (if it is configured).
+As you might recall, in [chapter 1](../2.1-name-resolution-1-getting-started/README.md#how-does-your-computer-know-where-to-go-to-resolve-a-name), we took a look at the contents of `/etc/nsswitch.conf`. We saw that the `hosts` line provided instructions for how to resolve a name. The order runs sequentially through each entry in that line; it starts with looking at the `files` on the system (i.e. `/etc/hosts`), and, if it doesn't find the name there, then it should use `dns` (if it is configured).
 
 Let's start off by taking a quick look at the `/etc/nsswitch.conf` file on our machines now.
 
@@ -474,7 +474,7 @@ root@host-c:/# links http://host-f.local
 
 As [we went over previously](#avahi-and-avahi-daemon), Avahi name resolution works by editing the `hosts` entry in `/etc/nsswitch.conf`. Even if we have the `avahi-daemon` running on a machine, if we remove the `mdns4_minimal` entry from the `hosts` in `/etc/nsswitch.conf`, we'll break the name resolution process. Try it for yourself.
 
-Can you explain why? If you're not comfortable with your explanation yet, review how a computer knows how to resolve a name in [chapter 1](../name-resolution-1-getting-started/README.md#how-does-your-computer-know-where-to-go-to-resolve-a-name).
+Can you explain why? If you're not comfortable with your explanation yet, review how a computer knows how to resolve a name in [chapter 1](../2.1-name-resolution-1-getting-started/README.md#how-does-your-computer-know-where-to-go-to-resolve-a-name).
 
 ## Appendix
 

--- a/chapters/2.3-name-resolution-3-simple-dns/README.md
+++ b/chapters/2.3-name-resolution-3-simple-dns/README.md
@@ -207,7 +207,7 @@ The configuration we have done so far is to get knot running. Now, we need to co
 
 So now, in order to use the Knot server's information about the names on our internet, we need to tell the `host-dns` machine to use **itself** to resolve hostnames. This pattern should be familiar since we had to configure either `/etc/hosts` or `/etc/nsswitch.conf` for similar ends in our earlier exploration of name resolution.
 
-We talked in [chapter 1 of this section](../name-resolution-1-getting-started/README.md#how-does-your-computer-know-where-to-go-to-resolve-a-name) about how a machine knows who to ask to resolve a name. Take a moment and have a look at the `/etc/resolv.conf` file on the `host-dns` machine:
+We talked in [chapter 1 of this section](../2.1-name-resolution-1-getting-started/README.md#how-does-your-computer-know-where-to-go-to-resolve-a-name) about how a machine knows who to ask to resolve a name. Take a moment and have a look at the `/etc/resolv.conf` file on the `host-dns` machine:
 
 ```bash
 nano /etc/resolv.conf

--- a/chapters/2.4-name-resolution-recursive-dns/README.md
+++ b/chapters/2.4-name-resolution-recursive-dns/README.md
@@ -392,7 +392,7 @@ Next, we're going to to play around in this system!
 
 ## 1. Explore and make changes to the DNS infrastructure of our internet
 
-This leads us to our map! If you need help understanding this map, check out our [appendix on how to read network maps](../../../appendix/how-to-read-a-network-map.md).
+This leads us to our map! If you need help understanding this map, check out our [appendix on how to read network maps](../../appendix/how-to-read-a-network-map.md).
 
 [![Network map of a large internetwork](../../img/network-maps/name-resolution/recursive-dns.svg
  "Network map of a large internetwork")](../../img/network-maps/name-resolution/recursive-dns.svg)
@@ -1033,7 +1033,7 @@ In your first window, you should see A LOT of output in your `tcpdump`. Let's ta
 21:11:07.561667 ARP, Reply 1.2.0.100 is-at 02:42:01:02:00:64, length 28
 ```
 
-**A standard ARP request.** You may or may not see these two lines. But either way, we can ignore them. We'ver covered these kinds of messages in previous chapters. For more on this, checkout the [IP and MAC addresses appendix](../../../appendix/ip-and-mac-addresses.md)
+**A standard ARP request.** You may or may not see these two lines. But either way, we can ignore them. We'ver covered these kinds of messages in previous chapters. For more on this, checkout the [IP and MAC addresses appendix](../../appendix/ip-and-mac-addresses.md)
 
 ```bash
 21:11:07.561754 IP 1.1.0.200.48600 > 1.2.0.100.53: 48085+ [1au] A? www.awesomecat.com. (59)

--- a/miscellaneous/routing-pitfalls.md
+++ b/miscellaneous/routing-pitfalls.md
@@ -125,7 +125,7 @@ Now, we can `ping` from router3 => server! Huzzah! Progress!!!
 
 When we initially created our broken set up for troubleshooting network problems in Chapter 4, we found that packets were getting mysteriously dropped where we weren't expecting them to be... Here's the deal. We had set up an asymmetric routing situation where one router was pointing to another over a peer-to-peer route, but the router receiving the request had a different route back for the response. This is a necessary thing in the wild; it allows flexibility in the internet. However, linux, the operating system we're starting our machines with, has opinions on this. If our linux machines see that they should send response packets out a different interface than the request packets came in on, by default, they will drop them on the floor.
 
-To fix this problem, we need to override this configuration. If you look in your [docker-compose.yml file](../004-lrg-internet/docker-compose.yml) for Chapter 4, you'll see that each router has some more `sysctl` configuration setup that look something like:
+To fix this problem, we need to override this configuration. If you look in your [docker-compose.yml file](../chapters/1.3-routing-internet-chonk/docker-compose.yml) for Chapter 4, you'll see that each router has some more `sysctl` configuration setup that look something like:
 
 ```yml
 - net.ipv4.conf.all.rp_filter=0


### PR DESCRIPTION
fixes: markdown tables and spacing; link updates

Convert tables from HTML to Markdown (9bd4ff0 should have been included in
changeset #66).

Apply the same image link embedding in markdown links as in #65 for the Smol
(SMOL?) Internet chapter, recently updated in #64.  See 664bfe6.

Note also, that I've found at least one Markdown engine that dislikes this
technique.  The lack of clear specification on which elements can contain what
other elements allows this sort of ambiguity.  For now, I think we can leave
it.  I will try to figure out if this is generally supported or supportable
and, if the answer is negative, I will create a separate pull-request to undo
the changes I made in #65.

Adhere to markdown whitespace-sensitivity on more files.  See b0eeef6.

Update all of the markdown link file-interlinking to be accurate with current
chapter and appendix layout.  See c602428.