### PR TITLE
improve image handling: link reference definitions

### DIFF
--- a/appendix/how-to-read-a-network-map.md
+++ b/appendix/how-to-read-a-network-map.md
@@ -6,8 +6,7 @@ Everything that we build in this project depends on us understanding the shape o
 
 Let's start with a very simple network map:
 
-[![basic-network-map](../img/network-maps/basic-network-map.svg
- "Basic Network Map")](../img/network-maps/basic-network-map.svg)
+[![basic network map][basic network map]][basic network map]
 
 So, what's going on here? First, what's probably most obvious about this map is that we have 2 machines on our network: a `Client` and a `Server`. Now, look at how each machine has a thin line coming out of it that connects it to a thicker line. That thick line symbolizes the network, and the thin lines from each machine symbolize their connections to that network.
 
@@ -19,8 +18,7 @@ So we've identified that the network is `10.1.1.0/24`, but we also need to know 
 
 So, we now know how to read a network map for a single network. But we're looking to build a full internet! That means multiple networks! Let's look at a slightly more complicated network map:
 
-[![smol-internet-network-map](../img/network-maps/smol-internet-network-map.svg
- "A Smol Internet Network Map")](../img/network-maps/smol-internet-network-map.svg)
+[![smol internet map][smol internet map]][smol internet map]
 
 OK, some of this should already look familiar. See if you can identify each of the following:
 
@@ -40,10 +38,21 @@ When we look at this network map, we can see that the `Router` has a connection 
 
 Alright, let's make this more interesting. Take a look at this slightly chonkier internet map:
 
-[![chonky-internet-network-map](../img/network-maps/internet-chonk-network-map.svg
- "A Chonky Internet Network Map")](../img/network-maps/internet-chonk-network-map.svg)
+[![chonky internet map][chonky internet map]][chonky internet map]
 
 See if you can complete the following exercises:
 
 1. What is `Server`'s IP address? What is `Router4`'s IP address on `2.1.1.0/29`?
 2. Use the lines that connect the machines to their networks to find a path for requests from `Client` to reach `Server`. 3. What do you think is the best path? Write down the IP addresses of each machine that will be used in that path.
+
+<!-- Links, reference style, inside docset -->
+[basic network map]:         ../img/network-maps/basic-network-map.svg
+                             "Basic Network Map"
+
+[smol internet map]:         ../img/network-maps/smol-internet-network-map.svg
+                             "A Smol Internet Network Map"
+
+[chonky internet map]:       ../img/network-maps/internet-chonk-network-map.svg
+                             "A Chonky Internet Network Map"
+
+<!-- end of file -->

--- a/appendix/recursive-dns.md
+++ b/appendix/recursive-dns.md
@@ -22,8 +22,7 @@ But why go through all this process? Why don't we just have those root servers a
 
 Before we can look at the process, we need to learn a little bit about the specific machines involved in DNS. We'll use a new network map with a few new machines defined on it:
 
-[![large internet with DNS infrastructure](../img/network-maps/name-resolution/recursive-dns.svg
- "large internet with DNS infrastructure")](../img/network-maps/name-resolution/recursive-dns.svg)
+[![large internet with DNS infrastructure][largenet DNS infra]][largenet DNS infra]
 
 Let's briefly break down what we're seeing in this network map. If you haven't already, it would behoove you to read over [How to Read a Network Map](how-to-read-a-network-map.md) before continuing this section.
 
@@ -44,20 +43,17 @@ _**NOTE** For the purposes of this explanation, we're going to ignore that cachi
 
 First. Let’s just define the actual goal of what we’re trying to accomplish. Using the network map above, we're going to pretend we're sitting on a client machine.
 
-[![large internet with DNS infrastructure with a pointer to the client machine](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg
- "large internet with DNS infrastructure with a pointer to the client machine")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg)
+[![large internet with DNS infrastructure with a pointer to the client machine][largenet DNS infra client]][largenet DNS infra client]
 
 Now, the user on this machine really wants to go visit `www.awesomecat.com`. Before the user can revel in GIFs and shorts of cats being awesome in the world, they need to resolve `www.awesomecat.com` to an IP address. The first thing this machine is going to do is send a request to their ISP's (Comcast in this case) recursive resolver.
 
-[![large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg
- "large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg)
+[![large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted][largenet DNS infra client-recursive]][largenet DNS infra client-recursive]
 
 The recursive resolver's job is to keep asking questions about what the DNS records are for a name until it gets a final answer. It will continue to initiate new requests until it either receives a response with the DNS records it was looking for or it receives an error. Only then will it respond back to the client.
 
 So, what's the first thing it needs to do? It doesn't know what server on the internet might know about `www.awesomecat.com`. Fortunately, every resolver comes installed with a file called [root.hints](https://www.internic.net/domain/named.root). This file provides the resolver the IP addresses of ALL of the root servers around the world. Since, for this explanation, we're ignoring the cache, the only thing the resolver knows about on the internet are those root servers. It will start by firing off a request to the Root DNS servers, asking them what the IP address is for `www.awesomecat.com`.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg)
+[![large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted][largenet DNS infra recursive-root]][largenet DNS infra recursive-root]
 
 The role of the Root DNS server on The Internet is simple. All they do is tell the resolver which Top Level Domain (TLD) servers to go to. Root DNS servers don't know all the DNS records for every domain on the internet. That would be way too many requests and waaaaaaaay too many domain names! What they do know is where the next step to find those answers lives.
 
@@ -65,9 +61,7 @@ Let's look at the domain we're attempting to lookup again: `www.awesomecat.com`.
 
 Our resolver receives the response back from the Root server, and it recognizes that this is not the final answer it's looking for. But! It also sees that it now has IP addresses of another server that has more information about the domain it's attempting to look up! So, our stalwart resolver fires off requests to the `COM` TLD servers.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg)
-
+[![large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted][largenet DNS infra recursive-comtld]][largenet DNS infra recursive-comtld]
 
 Much like the Root DNS server, our TLD servers see way too much traffic to be able to provide answers to every DNS query that hits them. Instead, they too delegate.
 
@@ -77,8 +71,7 @@ So in the story of our little resolver trying to find the IP address for `www.aw
 
 Our resolver receives that response, and undeterred, it initiates another new request, this time to the Authoritative server it just learned about.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted")](../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg)
+[![large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted][largenet DNS infra recursive-auth]][largenet DNS infra recursive-auth]
 
 The request lands on the Authoritative DNS server for this domain, and that server actually knows about the domain! It's able to send back an IP address for a server that knows how to handle queries for `www.awesomecat.com`!!!
 
@@ -369,3 +362,24 @@ So let's review what just happened here.
 - Once the resolver has an answer, it will send the final response back to the client who initiated the query.
 
 If you'd like to play around in this system, checkout our chapter on [name resolution with recursive DNS](../chapters/2.4-name-resolution-recursive-dns/README.md)!
+
+<!-- Links, reference style, inside docset -->
+[largenet DNS infra]:        ../img/network-maps/name-resolution/recursive-dns.svg
+                             "large internet with DNS infrastructure"
+
+[largenet DNS infra client]: ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg
+                             "large internet with DNS infrastructure with a pointer to the client machine"
+
+[largenet DNS infra client-recursive]: ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg
+                                       "large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted"
+
+[largenet DNS infra recursive-root]:   ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg
+                                       "large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted"
+
+[largenet DNS infra recursive-comtld]: ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg
+                                       "large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted"
+
+[largenet DNS infra recursive-auth]:   ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg
+                                       "large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted"
+
+<!-- end of file -->

--- a/chapters/1.1-routing-getting-started/README.md
+++ b/chapters/1.1-routing-getting-started/README.md
@@ -6,14 +6,13 @@ We want to build a simple network where two machines can ping each other. To kee
 
 Here's what we expect our network to look like by the end of this chapter:
 
-[![basic-network-map](../../img/network-maps/basic-network-map.svg
- "Basic Network Map")](../../img/network-maps/basic-network-map.svg)
+[![Basic Network Map][basic network map]][basic network map]
 
 In this diagram, there are 2 machines, `client` and `server`, who are a single network, `10.1.1.0/24`. That network can be understood as: all IP addresses in the range from `10.1.1.0` through `10.1.1.255`. Any machine on that network will have an IP address that is within that range, so `client` has the IP address `10.1.1.3` and `server` has the IP address `10.1.1.2`.
 
-To understand more about reading network maps, please review the [appendix on How to Read a Network Map](../../appendix/how-to-read-a-network-map.md)!
+To understand more about reading network maps, please review the [appendix on How to Read a Network Map][appendix netmap]!
 
-To understand more about network addresses, check out the [appendix entry on Prefixes and Subnet Masks](../../appendix/prefixes-and-subnet-masks.md)!
+To understand more about network addresses, check out the [appendix entry on Prefixes and Subnet Masks][appendix prefixes]!
 
 ## Running your docker container
 
@@ -35,11 +34,11 @@ To do so:
 1. `docker run -d --cap-add=NET_ADMIN --name=client $DOCKER_IMAGE`
 
 >**📝 NOTE:**
-> What is this `--cap-add=NET_ADMIN` all about, you ask? Check the "Problem Solving" section at the bottom for more information! Also see [this Stack Overflow post](https://stackoverflow.com/questions/27708376/why-am-i-getting-an-rtnetlink-operation-not-permitted-when-using-pipework-with-d) for more details.
+> What is this `--cap-add=NET_ADMIN` all about, you ask? Check the "Problem Solving" section at the bottom for more information! Also see [this Stack Overflow post on RTNETLINK and Docker][stackoverflow rtnetlink] for more details.
 
 ## Build a Network
 
-Now that we've got some machines up and running, let's network them together! To start with, let's just verify that `client` and `server` can't already talk to each other. We can check this by running a very simple program called [`ping`](../command-reference-guide.md#ping). We can provide `ping` with an IP address and it will see if it can send a simple request to the machine at the address provided. If a machine receives the type of request `ping` sends, it will send a response back. We're expecting there to be no response when `client` tries to `ping` `server`.
+Now that we've got some machines up and running, let's network them together! To start with, let's just verify that `client` and `server` can't already talk to each other. We can check this by running a very simple program called [`ping`][ref ping]. We can provide `ping` with an IP address and it will see if it can send a simple request to the machine at the address provided. If a machine receives the type of request `ping` sends, it will send a response back. We're expecting there to be no response when `client` tries to `ping` `server`.
 
 ### Check the current state
 
@@ -49,7 +48,7 @@ Let's start by hopping onto `server`:
 docker exec -it server /bin/bash
 ```
 
-In order for `client` to `ping` `server`, we'll need to get `server`'s IP address. Let's start by seeing what IP address configuration Docker automatically created for `server` when it created the machine. There's a very simple command with a lot of confusing output that we can run to get this: [`ip addr`](../command-reference-guide.md#ip-addr).
+In order for `client` to `ping` `server`, we'll need to get `server`'s IP address. Let's start by seeing what IP address configuration Docker automatically created for `server` when it created the machine. There's a very simple command with a lot of confusing output that we can run to get this: [`ip addr`][ref ip addr].
 
 ``` bash
 root@3daaaf641c2d:/# ip addr
@@ -63,7 +62,7 @@ root@3daaaf641c2d:/# ip addr
        valid_lft forever preferred_lft forever
 ```
 
-There's a lot going on here, and we'll get more familiar with this output in future chapters. But, for now, what we're seeing is 2 network [interfaces](../glossary.md#interface) on `server`, one for loopback, `lo`, which is used in networking for routing queries back to the machine that made the initial query. The other interface, `eth0` shows us that `server` already has an IP address, `172.17.0.2`, on an existing network, `172.17.0.2/16`. The exact address may be different on your machine, but the principles are the same.
+There's a lot going on here, and we'll get more familiar with this output in future chapters. But, for now, what we're seeing is 2 network [interfaces][glossary interface] on `server`, one for loopback, `lo`, which is used in networking for routing queries back to the machine that made the initial query. The other interface, `eth0` shows us that `server` already has an IP address, `172.17.0.2`, on an existing network, `172.17.0.2/16`. The exact address may be different on your machine, but the principles are the same.
 
 Uh oh... Let's hopon `client` and see if that machine is on the same network:
 
@@ -135,7 +134,7 @@ As the message indicates, that network is no longer available. `client` doesn't 
 
 ### Add our own IP address configuration
 
-Now that we've removed the default network docker created, let's get started creating a network of our own! Let's add IP addresses to each of these containers using the `ip addr add` command. In this example, we want to use the `10.1.1.0/24` network for these containers. `10.0.0.0/8` is one of the networks identified in [RFC 1918](https://www.rfc-editor.org/rfc/rfc1918) that is exclusively used for _private_ networking. This means that any IP packet that reaches the internet with an IP address in this range will be dropped. This is helpful in our tutorial because if our system is misconfigured to route to the Internet, we don't want a false-positive for ping tests. Therefore on `server`, we use the command
+Now that we've removed the default network docker created, let's get started creating a network of our own! Let's add IP addresses to each of these containers using the `ip addr add` command. In this example, we want to use the `10.1.1.0/24` network for these containers. `10.0.0.0/8` is one of the networks identified in [RFC 1918][RFC 1918] that is exclusively used for _private_ networking. This means that any IP packet that reaches the internet with an IP address in this range will be dropped. This is helpful in our tutorial because if our system is misconfigured to route to the Internet, we don't want a false-positive for ping tests. Therefore on `server`, we use the command
 
 `ip addr add 10.1.1.2/24 dev eth0`
 
@@ -145,7 +144,7 @@ But wait... why are we ending our addresses with `.2` and `.3`? Why aren't we st
 
 ### Test the network connection
 
-Here, we're going to start exploring with a networking tool called [`tcpdump`](../command-reference-guide.md#tcpdump). `tcpdump` "sniffs" ethernet frames on the network interface identified in the command. What we'll end up running on `server` is:
+Here, we're going to start exploring with a networking tool called [`tcpdump`][ref tcpdump]. `tcpdump` "sniffs" ethernet frames on the network interface identified in the command. What we'll end up running on `server` is:
 
 ```bash
 tcpdump -ni eth0
@@ -221,7 +220,7 @@ Basically, all you need to know about this is that `ping` is a program that send
 19:52:30.297112 ARP, Reply 10.1.1.2 is-at 02:42:ac:16:00:03, length 28
 ```
 
-ARP, which stands for Address Resolution Protocol,  is a protocol that allows a machine that is connected locally on one network to talk to another machine that is also connected to that same network (as opposed to a machine that wants to communicate over multiple networks). To learn more about ARP, checkout the [prefixes and subnet masks appendix](../../appendix/prefixes-and-subnet-masks.md).
+ARP, which stands for Address Resolution Protocol,  is a protocol that allows a machine that is connected locally on one network to talk to another machine that is also connected to that same network (as opposed to a machine that wants to communicate over multiple networks). To learn more about ARP, checkout the [prefixes and subnet masks appendix][appendix prefixes].
 
 After seeing the ARP packets go back and forth (which establish the ability for those two containers to talk to each other on the local network), we see the ICMP echo-request and echo-reply packets go back and forth in our `tcpdump` output.
 
@@ -269,10 +268,10 @@ At this point, there are a whole bunch of manual steps to get all this going.  N
 Make sure you're currently in the directory for this chapter. We are going to use the `docker-compose` command which uses the [docker-compose.yml](docker-compose.yml) file in this directory to build, configure, and start our two containers on our network. If you check that file, you'll see that we're creating:
 
 - 1 network
-    - ten-one-net (`10.1.1.0/24`)
+  - ten-one-net (`10.1.1.0/24`)
 - 2 services, each with an interface on ten-one-net
-    - client (`10.1.1.3`)
-    - server (`10.1.1.2`)
+  - client (`10.1.1.3`)
+  - server (`10.1.1.2`)
 
 To use this magical file to automate building out machines on our network, use the following command:
 
@@ -296,3 +295,21 @@ ip: RTNETLINK answers: Operation not permitted
 ```
 
 The solution for the problem was adding the permission `--cap-add=NET_ADMIN` when running `docker run` to get docker to allow us to be able to edit them.
+
+<!-- Links, reference style, inside docset -->
+
+[basic network map]:        ../../img/network-maps/basic-network-map.svg
+[appendix netmap]:          ../../appendix/how-to-read-a-network-map.md
+[appendix prefixes]:        ../../appendix/prefixes-and-subnet-masks.md
+[ref ip addr]:              ../command-reference-guide.md#ip-addr
+[ref ping]:                 ../command-reference-guide.md#ping
+[ref tcpdump]:              ../command-reference-guide.md#tcpdump
+[glossary interface]:       ../glossary.md#interface
+
+<!-- Links, reference style, to external resources -->
+[ext icmp responses]:        https://docs.netapp.com/us-en/e-series-santricity/sm-hardware/what-are-icmp-ping-responses.html
+[RFC 1918]:                  https://www.rfc-editor.org/rfc/rfc1918
+                             "RFC 1918"
+[stackoverflow rtnetlink]:   https://stackoverflow.com/questions/27708376/why-am-i-getting-an-rtnetlink-operation-not-permitted-when-using-pipework-with-d
+                             "Stackoverflow post on RTNETLINK and Docker"
+<!-- end of file -->

--- a/chapters/1.2-routing-smol-internet/README.md
+++ b/chapters/1.2-routing-smol-internet/README.md
@@ -6,8 +6,7 @@ In the previous chapter, we build a small network of 2 machines that could ping 
 
 Here's what we expect our internet to look like by the end of this chapter:
 
-[![smol-internet-network-map](../../img/network-maps/smol-internet-network-map.svg
- "A Smol Internet Network Map")](../../img/network-maps/smol-internet-network-map.svg)
+[![A Smol Internet Map][smol internet map]][smol internet map]
 
 You'll notice in this network diagram that we've built on the smol network from Chapter 1.1. Here, we've added a new network, `10.1.2.0/24`, and we've added a new machine, `router`. A [router](../glossary.md#router-aka-gateway) is a machine that has an [interface](../glossary.md#interface) on multiple networks and can forward packets across those networks. In this case, our router has an interface on both `10.1.1.0/24` and `10.1.2.0/24`.
 
@@ -372,3 +371,10 @@ For the sake of ensuring the rest of this chapter works as expected, we will not
 ```
 
 Each of the machines say `0 packets dropped by kernel`. Ummm… if the packets didn’t make it back to `server` and the packets weren’t dropped… where did they go? Well, `client` still dropped the packets. The `0 packets dropped by kernel` count isn't the number of packets dropped in total; it's the number of packets dropped *by tcpdump*. Specifically, `tcpdump` would drop those packets [because of buffer overflow](https://unix.stackexchange.com/questions/144794/why-would-the-kernel-drop-packets).
+
+<!-- Links, reference style, inside docset -->
+
+[smol internet map]:         ../../img/network-maps/smol-internet-network-map.svg
+                             "A Smol Internet Network Map"
+
+<!-- end of file -->

--- a/chapters/2.1-name-resolution-1-getting-started/README.md
+++ b/chapters/2.1-name-resolution-1-getting-started/README.md
@@ -6,8 +6,7 @@ What is name resolution? What problem(s) does it solve? In previous chapters, we
 
 Let's take a look at the internet we'll be working with for this chapter. You'll notice we've made some changes from the network diagrams we've used in other chapters. In _this_ internet, we have a bunch of [hosts](../glossary.md#host) that would like to communicate with each other:
 
-[![our-inter-network](../../img/network-maps/name-resolution/nr-getting-started.svg
- "Our Inter-network")](../../img/network-maps/name-resolution/nr-getting-started.svg)
+[![Our Inter-network][our inter network]][our inter network]
 
 Let's say we set this internet up for sharing fun pictures. Perhaps your passion is dancing photos, and host A (1.0.0.101) contains a massive library of `.jpg` files of this genre. Perhaps your friend Squee's passion is adorable kitty pictures, and their host B (5.0.0.102) has photos of that kind. When all of our friends set up their image-sharing hosts, we're going to end up with a bunch of machines that contain specific files we want access to.
 
@@ -184,7 +183,14 @@ root@host-a:/# links http://host-a
 
 As soon as you run this command, you'll see the full-screen text-based web-browsing majesty that is links:
 
-[![links-welcome-screen](../../img/links-welcome.jpg
- "links welcome screen")](../../img/links-welcome.jpg)
+[![links welcome screen][links-welcome-screen]][links-welcome-screen]
 
 Press `<enter>` on your keyboard to dismiss the welcome message. This is a text-based app to browse web-pages. It uses arrow-keys and tabs and enter and backspace in relatively intuitive way. Feel free to browse the documentation for it if you get stuck. Enjoy the amazing images! Also, notice that you can follow hyperlinks to all the other servers in this internet and explore the images on those systems as well!
+
+<!-- Links, reference style, inside docset -->
+[our inter network]:         ../../img/network-maps/name-resolution/nr-getting-started.svg
+                             "Our Inter-network"
+[links-welcome-screen]:      ../../img/links-welcome.jpg
+                             "links welcome screen"
+
+<!-- end of file -->

--- a/chapters/2.2-name-resolution-2-host-synchronization/README.md
+++ b/chapters/2.2-name-resolution-2-host-synchronization/README.md
@@ -12,8 +12,7 @@ Let's start with the simplest thing we can do: we're gonna head down the route o
 
 First, let's check out what our little internet looks like for this chapter:
 
-[![our-inter-network](../../img/network-maps/name-resolution/nr-multicast.svg
- "Our Inter-network")](../../img/network-maps/name-resolution/nr-multicast.svg)
+[!["Our Inter-network"][our inter network]][our inter network]
 
 The significant things to note about this internet are that we have 2 machines on one network, `host-c` and `host-f` are on `6.0.0.0/8`, and we added a new host, `host-h`, to the `4.0.0.0/8` network. `host-h` is only one hop away from `host-c` and `host-f`. This means that requests from `host-h` <=> `host-c` only need to be routed through one router. This simplifies what we're looking at when we are checking what's happening on our internet. We wanted to have a request path that involved one and only one router; adding `host-h` handled that for us.
 
@@ -438,8 +437,7 @@ Previously, we saw `router-3` proxying the request for name resolution for `host
 
 The name resolution request flow looks something like this:
 
-[![flowchart of proxy broadcast through our internet](../../img/network-maps/name-resolution/proxy-broadcast.svg
- "flowchart of proxy broadcast through our internet")](../../img/network-maps/name-resolution/proxy-broadcast.svg)
+[!["flowchart of proxy broadcast through our internet"][flowchart proxy broadcast]][flowchart proxy broadcast]
 
 Each arrow in this diagram indicates a new proxied request for name resolution for `host-h.local`. The color of the arrows indicates how far down the proxy chain that request is.
 
@@ -453,8 +451,7 @@ The result of these behaviors is that messages don't go around the internet fore
 
 Next, let's look at how the response makes its way to every machine as well.
 
-[![flowchart of a proxy response through our internet](../../img/network-maps/name-resolution/proxy-response.svg
- "flowchart of a proxy response through our internet")](../../img/network-maps/name-resolution/proxy-response.svg)
+[!["flowchart of proxy response through our internet"][flowchart proxy response]][flowchart proxy response]
 
 Here, we see that `host-h` generates the response message that gets broadcast to every router on the `4.0.0.0/8` network. Each router then proxies that message to each machine on each other network it has an interface on. As each router, in turn, does the same thing, this allows the response to flood back to every machine on the internet.
 
@@ -491,3 +488,15 @@ We've talked a lot in this chapter about multicast. But what makes multicast dif
 **Multicast** is another routing scheme which sends packets to many machines at once. Unlike "broadcast" packets, there are special registered multicast addresses that carry semantic meaning. We saw that the IP address `224.0.0.51`, for example, is used for multicast name-resolution. Machines that care about multicast name-resolution will listen for broadcast messages to this IP address and will respond accordingly. Furthermore, multicast is just broadcast that **could** be routed across multiple networks, but, in practice, this is rarely ever done.
 
 ![an image of routing schemes](https://bunnyacademy.b-cdn.net/what-is-routing-scheme.svg)
+
+<!-- Links, reference style, inside docset -->
+[our inter network]:         ../../img/network-maps/name-resolution/nr-multicast.svg
+                             "Our Inter-network"
+
+[flowchart proxy broadcast]: ../../img/network-maps/name-resolution/proxy-broadcast.svg
+                             "flowchart of proxy broadcast through our internet"
+
+[flowchart proxy response]:  ../../img/network-maps/name-resolution/proxy-response.svg
+                             "flowchart of a proxy response through our internet"
+
+<!-- end of file -->

--- a/chapters/2.3-name-resolution-3-simple-dns/README.md
+++ b/chapters/2.3-name-resolution-3-simple-dns/README.md
@@ -13,8 +13,7 @@ For this chapter, we want to build a single server that is responsible for knowi
 
 Let's look at the internet we'll be working with for this chapter:
 
-[![our-inter-network](../../img/network-maps/name-resolution/basic-dns-internet.svg
- "Our Inter-network")](../../img/network-maps/name-resolution/basic-dns-internet.svg)
+[!["Our Inter-network")][our inter network]][our inter network]
 
 Notice that our internet now has a server called `DNS` at `2.0.0.107`. This server provides Authoritative DNS services for our internet. If you check the directory for this chapter, you'll see that there's a new Dockerfile entry: `Dockerfile_dns`. This Dockerfile builds its image from a base image that includes DNS server software called `knot`. To achieve our goal for this chapter, we will need to:
 
@@ -318,3 +317,9 @@ By the time you're done, you should be able to do the following:
 
 * on `host-a`, you should be able to run the command `ping host-d.byoi.net -w 2` and you should be able to get responses.
 * you should be able to `hopon host-d` (for example) and run `links http://host-c.byoi.net` and bring up the web page on that host.
+
+<!-- Links, reference style, inside docset -->
+[our inter network]:         ../../img/network-maps/name-resolution/nr-getting-started.svg
+                             "Our Inter-network"
+
+<!-- end of file -->

--- a/chapters/2.4-name-resolution-recursive-dns/README.md
+++ b/chapters/2.4-name-resolution-recursive-dns/README.md
@@ -43,8 +43,7 @@ But why go through all this process? Why don't we just have those root servers a
 
 Before we can look at the process, we need to learn a little bit about the specific machines involved in DNS. We'll use a new network map with a few new machines defined on it:
 
-[![large internet with DNS infrastructure](../../img/network-maps/name-resolution/recursive-dns.svg
- "large internet with DNS infrastructure")](../../img/network-maps/name-resolution/recursive-dns.svg)
+[![large internet with DNS infrastructure][largenet DNS infra]][largenet DNS infra]
 
 Let's briefly break down what we're seeing in this network map. If you haven't already, it would behoove you to read over [How to Read a Network Map](../../appendix/how-to-read-a-network-map.md) before continuing this section.
 
@@ -65,20 +64,17 @@ _**NOTE** For the purposes of this explanation, we're going to ignore that cachi
 
 First. Let’s just define the actual goal of what we’re trying to accomplish. Using the network map above, we're going to pretend we're sitting on a client machine.
 
-[![large internet with DNS infrastructure with a pointer to the client machine](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg
- "large internet with DNS infrastructure with a pointer to the client machine")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg)
+[![large internet with DNS infrastructure with a pointer to the client machine][largenet DNS infra client]][largenet DNS infra client]
 
 Now, the user on this machine really wants to go visit `www.awesomecat.com`. Before the user can revel in GIFs and shorts of cats being awesome in the world, they need to resolve `www.awesomecat.com` to an IP address. The first thing this machine is going to do is send a request to their ISP's (Comcast in this case) recursive resolver.
 
-[![large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg
- "large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg)
+[![large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted][largenet DNS infra client-recursive]][largenet DNS infra client-recursive]
 
 The recursive resolver's job is to keep asking questions about what the DNS records are for a name until it gets a final answer. It will continue to initiate new requests until it either receives a response with the DNS records it was looking for or it receives an error. Only then will it respond back to the client.
 
 So, what's the first thing it needs to do? It doesn't know what server on the internet might know about `www.awesomecat.com`. Fortunately, every resolver comes installed with a file called [root.hints](https://www.internic.net/domain/named.root). This file provides the resolver the IP addresses of ALL of the root servers around the world. Since, for this explanation, we're ignoring the cache, the only thing the resolver knows about on the internet are those root servers. It will start by firing off a request to the Root DNS servers, asking them what the IP address is for `www.awesomecat.com`.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg)
+[![large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted][largenet DNS infra recursive-root]][largenet DNS infra recursive-root]
 
 The role of the Root DNS server on The Internet is simple. All they do is tell the resolver which Top Level Domain (TLD) servers to go to. Root DNS servers don't know all the DNS records for every domain on the internet. That would be way too many requests and waaaaaaaay too many domain names! What they do know is where the next step to find those answers lives.
 
@@ -86,8 +82,7 @@ Let's look at the domain we're attempting to lookup again: `www.awesomecat.com`.
 
 Our resolver receives the response back from the Root server, and it recognizes that this is not the final answer it's looking for. But! It also sees that it now has IP addresses of another server that has more information about the domain it's attempting to look up! So, our stalwart resolver fires off requests to the `COM` TLD servers.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg)
+[![large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted][largenet DNS infra recursive-comtld]][largenet DNS infra recursive-comtld]
 
 Much like the Root DNS server, our TLD servers see way too much traffic to be able to provide answers to every DNS query that hits them. Instead, they too delegate.
 
@@ -97,8 +92,7 @@ So in the story of our little resolver trying to find the IP address for `www.aw
 
 Our resolver receives that response, and undeterred, it initiates another new request, this time to the Authoritative server it just learned about.
 
-[![large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg
- "large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted")](../../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg)
+[![large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted][largenet DNS infra recursive-auth]][largenet DNS infra recursive-auth]
 
 The request lands on the Authoritative DNS server for this domain, and that server actually knows about the domain! It's able to send back an IP address for a server that knows how to handle queries for `www.awesomecat.com`!!!
 
@@ -394,8 +388,7 @@ Next, we're going to to play around in this system!
 
 This leads us to our map! If you need help understanding this map, check out our [appendix on how to read network maps](../../appendix/how-to-read-a-network-map.md).
 
-[![Network map of a large internetwork](../../img/network-maps/name-resolution/recursive-dns.svg
- "Network map of a large internetwork")](../../img/network-maps/name-resolution/recursive-dns.svg)
+[![Network map of a large internetwork][netmap large internetwork]][netmap large internetwork]
 
 You might recognize some of these new machines from our previous description on how recursive DNS works. See if you can find the machines that are part of the complete DNS infrastructure, including:
 
@@ -945,21 +938,21 @@ You're done with the `rootdns-i` server. This DNS server is now ready to respond
 
 1. Set up the `knot.conf` file.
 
-Now that the root DNS servers are configured, we're going to set up our **new** top-level domain server. `hopon tlddns-a` to configure the `knot` server there.
+   Now that the root DNS servers are configured, we're going to set up our **new** top-level domain server. `hopon tlddns-a` to configure the `knot` server there.
 
-If we check the `/config/knot.conf` file, you'll see that we currently only have the `server` itself defined. We'll need the following text at the end of the file to add the new `.meow` zone:
+   If we check the `/config/knot.conf` file, you'll see that we currently only have the `server` itself defined. We'll need the following text at the end of the file to add the new `.meow` zone:
 
-```bash
-# Define the zone
-zone:
-  - domain: meow
-    file: "/etc/knot/meow.zone"
-    storage: "/var/lib/knot"
-```
+    ```bash
+    # Define the zone
+    zone:
+      - domain: meow
+        file: "/etc/knot/meow.zone"
+        storage: "/var/lib/knot"
+    ```
 
 2. Create the `meow.zone` zone
 
-Now that we've told `knot` where to find the file for the zone, we should actually go and make that file! Let's `vim /etc/knot/meow.zone` and add the zone content we want for this TLD.
+   Now that we've told `knot` where to find the file for the zone, we should actually go and make that file! Let's `vim /etc/knot/meow.zone` and add the zone content we want for this TLD.
 
 We've looked at several zone files already in this chapter. If you look at them, you might be able to find a pattern. We're going to be setting the zone file on this server, which will be very similar in pattern to the other TLD zone files on servers `tlddns-g`, `tlddns-n`, and `tlddns-v`. Go take a look at one of these other TLD DNS servers and use take a look at their zone files to use as a starting place for setting up this new server. If you get stuck, take a look at the [final directory](./final/dns-servers/tlddns-a/meow.zone) for some assistance.
 
@@ -995,7 +988,7 @@ meow.                   3600    IN      SOA     tlddns-a.aws.meow. tlddns-a.aws.
 **TEST 2** Query a root DNS server to see if it provides the same answer:
 
 ```bash
-$ dig @100.0.1.100 meow.
+dig @100.0.1.100 meow.
 ```
 
 ##### Next steps for future learning
@@ -1154,8 +1147,7 @@ That's it! What we just looked at should have felt pretty familiar in comparison
 
 Now that we've built out some of the infrastructure together, let's take a stab at adding a few more elements to this toy internet. First, we'd like to bring your attention to a new network, "RIPE":
 
-[![Network map including the RIPE network](../../img/network-maps/name-resolution/recursive-dns-final-exercises.svg
- "Network map including the RIPE network")](../../img/network-maps/name-resolution/recursive-dns-final-exercises.svg)
+[![Network map including the RIPE network][netmap with RIPE network]][netmap with RIPE network]
 
 So now we're going to have you do a couple more exercises to make sure you have enough practice configuring DNS-related software. To that end, we have a **new** rootdns and a **new** resolver. Your task is to configure them so they function correctly in our toy internet! In each case, it would be helpful to go check (and potentially copy) the config files for similar machines on our internet.
 
@@ -1316,3 +1308,30 @@ So what's the purpose of all these extra zone files, like `aws.net.zone`? We nee
 Dear lord... `resolver-c` just wants to know everything abou the internet. Each of these packets is part of `resolver-c` attempting to either learn about domains that were tangentially related to its attempt to resolve `www.awesomecat.com`. Plus there's some ARP request to learn about `router-c3` there at the end.
 
 Now that we've gone through reading the basic `tcpdump` output, we encourage the reader to go back through this exercise again, this time running `tcpdump -nvv` to get the verbose output. See if you can read what's happening with each request when you get even more information!
+
+<!-- Links, reference style, inside docset -->
+[largenet DNS infra]:        ../img/network-maps/name-resolution/recursive-dns.svg
+                             "large internet with DNS infrastructure"
+
+[largenet DNS infra client]: ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-1.svg
+                             "large internet with DNS infrastructure with a pointer to the client machine"
+
+[largenet DNS infra client-recursive]: ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-2.svg
+                                       "large internet with DNS infrastructure with the path between the client machine and the recursive resolver highlighted"
+
+[largenet DNS infra recursive-root]:   ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-3.svg
+                                       "large internet with DNS infrastructure with the path between the recursive resolver and the root DNS servers highlighted"
+
+[largenet DNS infra recursive-comtld]: ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-4.svg
+                                       "large internet with DNS infrastructure with the path between the recursive resolver and the COM TLD server highlighted"
+
+[largenet DNS infra recursive-auth]:   ../img/network-maps/name-resolution/recursive-dns-explanation/simplified-dns-map-5.svg
+                                       "large internet with DNS infrastructure with the path between the recursive resolver and the Authoritative DNS server highlighted"
+
+[netmap large internetwork]:           ../../img/network-maps/name-resolution/recursive-dns.svg
+                                       "Network map of a large internetwork"
+
+[netmap with RIPE network]:            ../../img/network-maps/name-resolution/recursive-dns-final-exercises.svg
+                                       "Network map including the RIPE network"
+
+<!-- end of file -->


### PR DESCRIPTION
Use link reference definitions instead of incorrectly nesting typical Markdown links into image definitions.

Link reference definitions are akin to footnotes. Each link reference definition has a name, and can be placed anywhere in a file though they usually are placed at the end.

In the flow of text, a link can be used (inserted) using [brackets]. The Markdown processor inserts the link (and optional title text) from the definition.  There are several useful forms of reference links, both inline in text and in definitions.

These links can be used in the same way that typical links and autolinks are used, and they allow the visual separation of the use of the link from the definition of the link.

See: https://spec.commonmark.org/0.31.2/#link-reference-definitions

Within complex document sets, reference links provide convenient management opportunity for interlinking.  Link destinations (i.e. to other files) can all be kept in the same section of the file, slightly easing the maintenance burden when moving files around. Because Markdown parsers do not render reference link definitions into the output, they can reside comfortably at the bottom of the file.

This is a better way of providing the image-handling technique that worked despite being invalid Markdown (see 0cd7e08 and 664bfe6d). The `pymarkdown` linter approves of this new approach (esspied in the documentation of the mkdocs project main README file).

Bonus:  In addition to switching all of the files to use this technique for the presentation of the images, see also a demonstrate the use of reference links a bit more completely in chapter 1.1, showing how to use them for external links.

P.S. The verb "pronk" is pretty nifty.